### PR TITLE
Feat: export group as global variant

### DIFF
--- a/packages/gizmo/src/Group.ts
+++ b/packages/gizmo/src/Group.ts
@@ -1,5 +1,5 @@
 import { BoundingBox, Renderer, Vector3, Matrix, Entity } from "oasis-engine";
-import { AnchorType, CoordinateType } from "./enums/GizmoState";
+import { AnchorType, CoordinateType } from "./enums/GroupState";
 
 /**
  * dirty flag for the group

--- a/packages/gizmo/src/enums/GizmoState.ts
+++ b/packages/gizmo/src/enums/GizmoState.ts
@@ -19,31 +19,3 @@ export enum State {
    */
   all = 0xf
 }
-
-/**
- * Gizmo Anchor State
- */
-export enum AnchorType {
-  /**
-   * positions the Gizmo at the actual pivot point
-   */
-  Pivot,
-  /**
-   * positions the Gizmo at the center of the selected entity or entities rendered bounds
-   */
-  Center
-}
-
-/**
- * Gizmo Coordinate State
- */
-export enum CoordinateType {
-  /**
-   * aligns to the selected entity or entities local space
-   */
-  Local,
-  /**
-   * aligns to the world space orientation
-   */
-  Global
-}

--- a/packages/gizmo/src/enums/GroupState.ts
+++ b/packages/gizmo/src/enums/GroupState.ts
@@ -1,0 +1,27 @@
+/**
+ * Gizmo Anchor State
+ */
+export enum AnchorType {
+  /**
+   * positions the Gizmo at the actual pivot point
+   */
+  Pivot,
+  /**
+   * positions the Gizmo at the center of the selected entity or entities rendered bounds
+   */
+  Center
+}
+
+/**
+ * Gizmo Coordinate State
+ */
+export enum CoordinateType {
+  /**
+   * aligns to the selected entity or entities local space
+   */
+  Local,
+  /**
+   * aligns to the world space orientation
+   */
+  Global
+}

--- a/packages/gizmo/src/index.ts
+++ b/packages/gizmo/src/index.ts
@@ -1,2 +1,5 @@
 export { Gizmo } from "./Gizmo";
-export { State, AnchorType, CoordinateType } from "./enums/GizmoState";
+export { Group } from "./Group";
+
+export { State } from "./enums/GizmoState";
+export { AnchorType, CoordinateType } from "./enums/GroupState";


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
feature: escalate class group to global level
### What is the current behavior? (You can also link to an open issue here)
group is a local variant and created within gizmo
### What is the new behavior (if this is a feature change)?
export group as a class, created along with gizmo by user
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Yes, init instead of set camera
### Other information: