### PR TITLE
Fix: calculate camera up direction when triggered

### DIFF
--- a/packages/controls/src/OrbitControl.ts
+++ b/packages/controls/src/OrbitControl.ts
@@ -248,6 +248,8 @@ export class OrbitControl extends Script {
 
   private _updateTransform(): void {
     const { cameraTransform, target, _tempVec3, _spherical, _sphericalDelta, _panOffset } = this;
+    cameraTransform.getWorldUp(_tempVec3);
+    this._atTheBack = _tempVec3.y <= 0;
     Vector3.subtract(cameraTransform.position, target, _tempVec3);
     _spherical.setFromVec3(_tempVec3, this._atTheBack);
     _spherical.theta += _sphericalDelta.theta;


### PR DESCRIPTION
considering camera's up direction may be changed when control is idle, need to calculate current up direction every time orbit control triggered