### PR TITLE
Fix: keep gizmo same size under ortho

### DIFF
--- a/packages/gizmo/src/Gizmo.ts
+++ b/packages/gizmo/src/Gizmo.ts
@@ -31,6 +31,8 @@ export class Gizmo extends Script {
   private _isStarted = false;
   private _isHovered = false;
   private _lastDistance: number = -1;
+  private _lastOrthoSize: number = -1;
+  private _lastIsOrtho: boolean = false;
 
   private _sceneCamera: Camera;
   private _layer: Layer;
@@ -112,7 +114,6 @@ export class Gizmo extends Script {
 
   constructor(entity: Entity) {
     super(entity);
-
     // @ts-ignore
     if (!this.entity.engine.physicsManager._initialized) {
       throw new Error("PhysicsManager is not initialized");
@@ -135,7 +136,6 @@ export class Gizmo extends Script {
     );
 
     this.layer = Layer.Layer29;
-
     // gizmo collider
     const sphereCollider = entity.addComponent(StaticCollider);
     const colliderShape = new SphereColliderShape();
@@ -155,6 +155,14 @@ export class Gizmo extends Script {
     const pointer = pointers.find((pointer: Pointer) => {
       return pointer.phase !== PointerPhase.Up && pointer.phase !== PointerPhase.Leave;
     });
+
+    if (this._lastIsOrtho !== this._sceneCamera.isOrthographic) {
+      this._lastIsOrtho = this._sceneCamera.isOrthographic;
+      this._traverseControl(this._type, (control) => {
+        this._type === State.all ? control.onSwitch() : control.onSwitch();
+      });
+    }
+
     if (this._isStarted) {
       if (pointer && (pointer.pressedButtons & PointerButton.Primary) !== 0) {
         if (pointer.deltaPosition.x !== 0 || pointer.deltaPosition.y !== 0) {
@@ -179,7 +187,16 @@ export class Gizmo extends Script {
         this._lastDistance = currDistance;
       }
 
-      if (this._group._gizmoTransformDirty || distanceDirty) {
+      let orthoSizeDirty = false;
+      if (
+        this._sceneCamera.isOrthographic &&
+        Math.abs(this._lastOrthoSize - this._sceneCamera.orthographicSize) > MathUtil.zeroTolerance
+      ) {
+        orthoSizeDirty = true;
+        this._lastOrthoSize = this._sceneCamera.orthographicSize;
+      }
+
+      if (this._group._gizmoTransformDirty || distanceDirty || orthoSizeDirty) {
         this._traverseControl(this._type, (control) => {
           this._type === State.all ? control.onUpdate(true) : control.onUpdate(false);
         });

--- a/packages/gizmo/src/Gizmo.ts
+++ b/packages/gizmo/src/Gizmo.ts
@@ -159,7 +159,7 @@ export class Gizmo extends Script {
     if (this._lastIsOrtho !== this._sceneCamera.isOrthographic) {
       this._lastIsOrtho = this._sceneCamera.isOrthographic;
       this._traverseControl(this._type, (control) => {
-        this._type === State.all ? control.onSwitch() : control.onSwitch();
+        this._type === State.all ? control.onSwitch(true) : control.onSwitch(false);
       });
     }
 

--- a/packages/gizmo/src/Rotate.ts
+++ b/packages/gizmo/src/Rotate.ts
@@ -232,15 +232,12 @@ export class RotateControl extends GizmoComponent {
   }
 
   onUpdate(isModified: boolean = false): void {
-    this._group.getWorldMatrix(this._tempMatrix);
-
-    this._isModified = isModified;
-    const s = this._getGizmoScale();
-    this.gizmoEntity.transform.worldMatrix = this.gizmoHelperEntity.transform.worldMatrix = this._tempMatrix.scale(
-      this._tempVec.set(s, s, s)
-    );
-
+    this._resizeControl(isModified);
     this._updateAxisTransform();
+  }
+
+  onSwitch() {
+    this._resizeControl();
   }
 
   private _setAxisSelected(axis: axisType, isSelected: boolean): void {
@@ -289,9 +286,13 @@ export class RotateControl extends GizmoComponent {
   private _getGizmoScale(): number {
     const cameraPosition = this._camera.entity.transform.worldPosition;
     this._group.getWorldPosition(this._tempVec);
-    return this._isModified
-      ? Vector3.distance(cameraPosition, this._tempVec) * Utils.scaleFactor * 0.8
-      : Vector3.distance(cameraPosition, this._tempVec) * Utils.scaleFactor;
+    if (this._camera.isOrthographic) {
+      return this._camera.orthographicSize * Utils.scaleFactor * 3;
+    } else {
+      return this._isModified
+        ? Vector3.distance(cameraPosition, this._tempVec) * Utils.scaleFactor * 0.8
+        : Vector3.distance(cameraPosition, this._tempVec) * Utils.scaleFactor;
+    }
   }
 
   private _updateAxisTransform(): void {
@@ -314,5 +315,15 @@ export class RotateControl extends GizmoComponent {
     Quaternion.rotationZ(Math.atan2(this._cameraPos.y, this._cameraPos.x), tempQuat);
     this._axisZ.transform.rotationQuaternion = tempQuat;
     this._axisZHelper.transform.rotationQuaternion = tempQuat;
+  }
+
+  private _resizeControl(isModified: boolean = false): void {
+    this._group.getWorldMatrix(this._tempMatrix);
+
+    this._isModified = isModified;
+    const s = this._getGizmoScale();
+    this.gizmoEntity.transform.worldMatrix = this.gizmoHelperEntity.transform.worldMatrix = this._tempMatrix.scale(
+      this._tempVec.set(s, s, s)
+    );
   }
 }

--- a/packages/gizmo/src/Rotate.ts
+++ b/packages/gizmo/src/Rotate.ts
@@ -236,8 +236,8 @@ export class RotateControl extends GizmoComponent {
     this._updateAxisTransform();
   }
 
-  onSwitch() {
-    this._resizeControl();
+  onSwitch(isModified: boolean = false) {
+    this._resizeControl(isModified);
   }
 
   private _setAxisSelected(axis: axisType, isSelected: boolean): void {
@@ -287,7 +287,9 @@ export class RotateControl extends GizmoComponent {
     const cameraPosition = this._camera.entity.transform.worldPosition;
     this._group.getWorldPosition(this._tempVec);
     if (this._camera.isOrthographic) {
-      return this._camera.orthographicSize * Utils.scaleFactor * 3;
+      return this._isModified
+        ? this._camera.orthographicSize * Utils.scaleFactor * 3 * 0.8
+        : this._camera.orthographicSize * Utils.scaleFactor * 3;
     } else {
       return this._isModified
         ? Vector3.distance(cameraPosition, this._tempVec) * Utils.scaleFactor * 0.8

--- a/packages/gizmo/src/Scale.ts
+++ b/packages/gizmo/src/Scale.ts
@@ -120,20 +120,11 @@ export class ScaleControl extends GizmoComponent {
   }
 
   onUpdate(isModified: boolean = false): void {
-    const { _tempVec0, _tempMat } = this;
-    const cameraPosition = this._camera.entity.transform.worldPosition;
-    this._group.getWorldMatrix(_tempMat);
-    const { elements: ele } = _tempMat;
-    _tempVec0.set(ele[12], ele[13], ele[14]);
+    this._resizeControl(isModified);
+  }
 
-    const s = isModified
-      ? Vector3.distance(cameraPosition, _tempVec0) * Utils.scaleFactor * 0.75
-      : Vector3.distance(cameraPosition, _tempVec0) * Utils.scaleFactor;
-
-    const sx = s / Math.sqrt(ele[0] ** 2 + ele[1] ** 2 + ele[2] ** 2);
-    const sy = s / Math.sqrt(ele[4] ** 2 + ele[5] ** 2 + ele[6] ** 2);
-    const sz = s / Math.sqrt(ele[8] ** 2 + ele[9] ** 2 + ele[10] ** 2);
-    this.entity.transform.worldMatrix = this._tempMat.scale(this._tempVec0.set(sx, sy, sz));
+  onSwitch() {
+    this._resizeControl();
   }
 
   private _initAxis(): void {
@@ -226,5 +217,28 @@ export class ScaleControl extends GizmoComponent {
     Vector3.transformCoordinate(ray.origin, worldToLocal, ray.origin);
     Vector3.transformNormal(ray.direction, worldToLocal, ray.direction);
     ray.getPoint(ray.intersectPlane(this._plane), out);
+  }
+
+  private _resizeControl(isModified: boolean = false): void {
+    const { _tempVec0, _tempMat } = this;
+    const cameraPosition = this._camera.entity.transform.worldPosition;
+    this._group.getWorldMatrix(_tempMat);
+
+    if (this._camera.isOrthographic) {
+      const s = this._camera.orthographicSize * Utils.scaleFactor * 3;
+      this.entity.transform.worldMatrix = this._tempMat.scale(this._tempVec0.set(s, s, s));
+    } else {
+      const { elements: ele } = _tempMat;
+      _tempVec0.set(ele[12], ele[13], ele[14]);
+
+      const s = isModified
+        ? Vector3.distance(cameraPosition, _tempVec0) * Utils.scaleFactor * 0.75
+        : Vector3.distance(cameraPosition, _tempVec0) * Utils.scaleFactor;
+
+      const sx = s / Math.sqrt(ele[0] ** 2 + ele[1] ** 2 + ele[2] ** 2);
+      const sy = s / Math.sqrt(ele[4] ** 2 + ele[5] ** 2 + ele[6] ** 2);
+      const sz = s / Math.sqrt(ele[8] ** 2 + ele[9] ** 2 + ele[10] ** 2);
+      this.entity.transform.worldMatrix = this._tempMat.scale(this._tempVec0.set(sx, sy, sz));
+    }
   }
 }

--- a/packages/gizmo/src/Scale.ts
+++ b/packages/gizmo/src/Scale.ts
@@ -123,8 +123,8 @@ export class ScaleControl extends GizmoComponent {
     this._resizeControl(isModified);
   }
 
-  onSwitch() {
-    this._resizeControl();
+  onSwitch(isModified: boolean = false) {
+    this._resizeControl(isModified);
   }
 
   private _initAxis(): void {
@@ -225,7 +225,10 @@ export class ScaleControl extends GizmoComponent {
     this._group.getWorldMatrix(_tempMat);
 
     if (this._camera.isOrthographic) {
-      const s = this._camera.orthographicSize * Utils.scaleFactor * 3;
+      const s = isModified
+        ? this._camera.orthographicSize * Utils.scaleFactor * 3 * 0.75
+        : this._camera.orthographicSize * Utils.scaleFactor * 3;
+
       this.entity.transform.worldMatrix = this._tempMat.scale(this._tempVec0.set(s, s, s));
     } else {
       const { elements: ele } = _tempMat;

--- a/packages/gizmo/src/Translate.ts
+++ b/packages/gizmo/src/Translate.ts
@@ -27,6 +27,7 @@ export class TranslateControl extends GizmoComponent {
   private _tempVec1: Vector3 = new Vector3();
   private _tempVec2: Vector3 = new Vector3();
   private _tempMat: Matrix = new Matrix();
+  private _tempScale: number = 1;
 
   constructor(entity: Entity) {
     super(entity);
@@ -113,14 +114,11 @@ export class TranslateControl extends GizmoComponent {
   }
 
   onUpdate(isModified: boolean = false): void {
-    const { _tempMat, _tempVec0 } = this;
-    const cameraPosition = this._camera.entity.transform.worldPosition;
-    this._group.getWorldMatrix(_tempMat);
-    _tempVec0.set(_tempMat.elements[12], _tempMat.elements[13], _tempMat.elements[14]);
-    const s = (this._scale = Vector3.distance(cameraPosition, _tempVec0) * Utils.scaleFactor);
-    this.gizmoEntity.transform.worldMatrix = this.gizmoHelperEntity.transform.worldMatrix = _tempMat.scale(
-      _tempVec0.set(s, s, s)
-    );
+    this._resizeControl();
+  }
+
+  onSwitch() {
+    this._resizeControl();
   }
 
   private _initAxis(): void {
@@ -237,5 +235,21 @@ export class TranslateControl extends GizmoComponent {
     Vector3.transformCoordinate(ray.origin, worldToLocal, ray.origin);
     Vector3.transformNormal(ray.direction, worldToLocal, ray.direction);
     ray.getPoint(ray.intersectPlane(this._plane), out);
+  }
+
+  private _resizeControl(): void {
+    const { _tempMat, _tempVec0 } = this;
+    const cameraPosition = this._camera.entity.transform.worldPosition;
+    this._group.getWorldMatrix(_tempMat);
+
+    if (this._camera.isOrthographic) {
+      this._tempScale = this._camera.orthographicSize * Utils.scaleFactor * 3;
+    } else {
+      _tempVec0.set(_tempMat.elements[12], _tempMat.elements[13], _tempMat.elements[14]);
+      this._tempScale = this._scale = Vector3.distance(cameraPosition, _tempVec0) * Utils.scaleFactor;
+    }
+    this.gizmoEntity.transform.worldMatrix = this.gizmoHelperEntity.transform.worldMatrix = _tempMat.scale(
+      _tempVec0.set(this._tempScale, this._tempScale, this._tempScale)
+    );
   }
 }

--- a/packages/gizmo/src/Translate.ts
+++ b/packages/gizmo/src/Translate.ts
@@ -114,7 +114,7 @@ export class TranslateControl extends GizmoComponent {
   }
 
   onUpdate(isModified: boolean = false): void {
-    this._resizeControl();
+    this._resizeControl(isModified);
   }
 
   onSwitch() {
@@ -237,7 +237,7 @@ export class TranslateControl extends GizmoComponent {
     ray.getPoint(ray.intersectPlane(this._plane), out);
   }
 
-  private _resizeControl(): void {
+  private _resizeControl(isModified: boolean = false): void {
     const { _tempMat, _tempVec0 } = this;
     const cameraPosition = this._camera.entity.transform.worldPosition;
     this._group.getWorldMatrix(_tempMat);

--- a/packages/gizmo/src/Type.ts
+++ b/packages/gizmo/src/Type.ts
@@ -29,7 +29,7 @@ export abstract class GizmoComponent extends Component {
   /** Called when gizmo's transform is dirty.*/
   abstract onUpdate(isModified: boolean): void;
   /** Called when camera switch between ortho and perps.*/
-  abstract onSwitch(): void;
+  abstract onSwitch(isModified: boolean): void;
 }
 
 export enum axisType {

--- a/packages/gizmo/src/Type.ts
+++ b/packages/gizmo/src/Type.ts
@@ -28,6 +28,8 @@ export abstract class GizmoComponent extends Component {
   abstract onMoveEnd(): void;
   /** Called when gizmo's transform is dirty.*/
   abstract onUpdate(isModified: boolean): void;
+  /** Called when camera switch between ortho and perps.*/
+  abstract onSwitch(): void;
 }
 
 export enum axisType {


### PR DESCRIPTION
keep gizmo same size when camera is ortho: 
1. orthoGraphicSize change, e.g. orthoControl use orthoGraphicSize for zoom in and out
2. camera distance change, e.g. orbitControl zoom in and out when camera is ortho