### PR TITLE
Adapt: adapt gizmo to new framebuffer picker

### DIFF
--- a/packages/framebuffer-picker/src/FramebufferPicker.ts
+++ b/packages/framebuffer-picker/src/FramebufferPicker.ts
@@ -33,8 +33,13 @@ export class FramebufferPicker extends Script {
   private _pickRenderTarget: RenderTarget;
   private _frameBufferSize: Vector2 = new Vector2(1024, 1024);
 
-  /** Frame buffer size.*/
-  frameBufferSize: Vector2 = new Vector2(1024, 1024);
+  get frameBufferSize(): Vector2 {
+    return this._frameBufferSize;
+  }
+
+  set frameBufferSize(value: Vector2) {
+    this._frameBufferSize = value;
+  }
 
   /**
    * @override

--- a/packages/gizmo/src/GizmoMaterial.ts
+++ b/packages/gizmo/src/GizmoMaterial.ts
@@ -1,0 +1,134 @@
+import {
+  Material,
+  Shader,
+  Color,
+  RenderQueueType,
+  Engine,
+  BlendFactor,
+  CullMode,
+  ShaderMacro,
+} from "oasis-engine";
+
+const vertexSource = `
+  uniform mat4 u_MVPMat;
+  uniform mat4 u_MVMat;
+  attribute vec3 POSITION;
+  #ifdef POS_CUTOFF
+  varying float v_Sub;
+  #endif
+  void main() {
+    gl_Position = u_MVPMat * vec4(POSITION, 1.0);
+    #ifdef POS_CUTOFF
+    v_Sub = gl_Position.w + u_MVMat[3][2];
+    #endif
+  }
+  `;
+
+const fragmentSource = `
+  uniform vec4 u_color;
+  #ifdef POS_CUTOFF
+  varying float v_Sub;
+  #endif
+  void main() {
+    gl_FragColor = u_color;
+    #ifdef POS_CUTOFF
+    gl_FragColor.a = step(v_Sub, 0.0);
+    #endif
+  }
+  `;
+
+Shader.create("gizmo-shader", vertexSource, fragmentSource);
+
+export class ArcMaterial extends Material {
+  private static _posCutoffMacro = ShaderMacro.getByName("POS_CUTOFF");
+  private _posCutOff = false;
+
+  set baseColor(val: Color) {
+    this.shaderData.setColor("u_color", val);
+  }
+
+  get baseColor() {
+    return this.shaderData.getColor("u_color");
+  }
+
+  set posCutOff(value: boolean) {
+    if (this._posCutOff !== value) {
+      this._posCutOff = value;
+      value
+        ? this.shaderData.enableMacro(ArcMaterial._posCutoffMacro)
+        : this.shaderData.disableMacro(ArcMaterial._posCutoffMacro);
+    }
+  }
+
+  constructor(engine: Engine) {
+    super(engine, Shader.find("gizmo-shader"));
+    this.renderState.renderQueueType = RenderQueueType.Transparent;
+    this.renderState.depthState.enabled = false;
+    this.renderState.rasterState.cullMode = CullMode.Off;
+
+    const target = this.renderState.blendState.targetBlendState;
+    const depthState = this.renderState.depthState;
+    target.enabled = true;
+    target.sourceColorBlendFactor = target.sourceAlphaBlendFactor =
+      BlendFactor.SourceAlpha;
+    target.destinationColorBlendFactor = target.destinationAlphaBlendFactor =
+      BlendFactor.OneMinusSourceAlpha;
+    depthState.writeEnabled = false;
+
+    this.shaderData.disableMacro(ArcMaterial._posCutoffMacro);
+  }
+}
+const vert = `
+uniform mat4 u_view_matrix;
+uniform mat4 u_projection_matrix;
+
+void main() {
+  vec4 world_pos = u_model_matrix * vec4(gl_Vertex.xyz, 1.0);
+  vec4 view_pos = u_view_matrix * world_pos;
+  vec4 clip_pos = u_projection_matrix * view_pos;
+  
+  gl_Position = clip_pos;
+  gl_PointSize = 1.0;
+  
+  vec3 cam_pos = vec3(u_view_matrix[3]);
+  vec3 dir = cam_pos - world_pos.xyz;
+  vec3 right = vec3(u_view_matrix[0]);
+  vec3 up = vec3(u_view_matrix[1]);
+  
+  vec3 normal = normalize(cross(right, up));
+  vec3 binormal = normalize(cross(normal, right));
+  
+  vec3 screen_pos = vec3(clip_pos.xy, clip_pos.z / clip_pos.w);
+  vec3 offset = screen_pos.x * right + screen_pos.y * up;
+  
+  vec3 final_pos = world_pos.xyz + (offset.x * binormal + offset.y * normal) * length(dir);
+  
+  gl_Position = u_projection_matrix * u_view_matrix * vec4(final_pos, 1.0);
+}
+`;
+
+const frag = `
+uniform vec4 u_color;
+void main() {
+  gl_FragColor = u_color;
+}
+`;
+
+Shader.create("gizmo-circle", vert, frag);
+
+export class CircleMaterial extends Material {
+  set baseColor(val: Color) {
+    this.shaderData.setColor("u_color", val);
+  }
+
+  get baseColor() {
+    return this.shaderData.getColor("u_color");
+  }
+
+  constructor(engine: Engine) {
+    super(engine, Shader.find("gizmo-circle"));
+    this.renderState.renderQueueType = RenderQueueType.Transparent;
+    this.renderState.depthState.enabled = false;
+    this.renderState.rasterState.cullMode = CullMode.Off;
+  }
+}

--- a/packages/gizmo/src/Rotate.ts
+++ b/packages/gizmo/src/Rotate.ts
@@ -241,8 +241,9 @@ export class RotateControl extends GizmoComponent {
         startP.x = pointerPosition.x;
         startP.y = pointerPosition.y;
 
-        this._camera.entity.transform.getWorldUp(this._startAxisY);
-        this._camera.entity.transform.getWorldForward(this._startAxisX);
+        this._startAxisY = this._camera.entity.transform.worldUp.clone();
+        this._startAxisX = this._camera.entity.transform.worldUp.clone();
+
         Vector3.cross(this._startAxisX, this._startAxisY, this._startAxisX);
 
         this._freeHelperEntity.transform.worldMatrix = this._startMatrix;

--- a/packages/gizmo/src/Utils.ts
+++ b/packages/gizmo/src/Utils.ts
@@ -1,7 +1,8 @@
-import { Engine, PrimitiveMesh, ModelMesh, CullMode } from "oasis-engine";
+import { Engine, PrimitiveMesh, ModelMesh, CullMode, Color } from "oasis-engine";
 import { State } from "./enums/GizmoState";
 import { GizmoMesh } from "./GizmoMesh";
 import { PlainColorMaterial } from "@oasis-engine-toolkit/custom-material";
+import { ArcMaterial } from "./GizmoMaterial";
 
 export class Utils {
   static rotateCircleRadius = 1.6;
@@ -15,9 +16,9 @@ export class Utils {
   static lightBlueMaterial: PlainColorMaterial;
   static invisibleMaterialTrans: PlainColorMaterial;
 
-  static redArcMaterial: PlainColorMaterial;
-  static greenArcMaterial: PlainColorMaterial;
-  static blueArcMaterial: PlainColorMaterial;
+  static redArcMaterial: ArcMaterial;
+  static greenArcMaterial: ArcMaterial;
+  static blueArcMaterial: ArcMaterial;
   static yellowMaterial: PlainColorMaterial;
   static rotatePlaneMaterial: PlainColorMaterial;
   static invisibleMaterialRotate: PlainColorMaterial;
@@ -58,9 +59,9 @@ export class Utils {
     Utils.invisibleMaterialTrans = this._createPlainColorMaterial(engine, State.translate, 0, 0, 0, 0);
 
     // rotate material
-    Utils.redArcMaterial = this._createPlainColorMaterial(engine, State.rotate, 1.0, 0.25, 0.25, 1.0);
-    Utils.greenArcMaterial = this._createPlainColorMaterial(engine, State.rotate, 0.5, 0.8, 0.2, 1);
-    Utils.blueArcMaterial = this._createPlainColorMaterial(engine, State.rotate, 0.3, 0.5, 1.0, 1);
+    Utils.redArcMaterial = this._createArcMaterial(engine, State.rotate, 1.0, 0.25, 0.25);
+    Utils.greenArcMaterial = this._createArcMaterial(engine, State.rotate, 0.5, 0.8, 0.2);
+    Utils.blueArcMaterial = this._createArcMaterial(engine, State.rotate, 0.3, 0.5, 1.0);
     Utils.yellowMaterial = this._createPlainColorMaterial(engine, State.rotate, 1.0, 0.95, 0.0, 1.0);
     Utils.rotatePlaneMaterial = this._createPlainColorMaterial(engine, State.rotate, 1.0, 0.95, 0.0, 0.2);
     Utils.rotatePlaneMaterial.renderState.rasterState.cullMode = CullMode.Off;
@@ -105,6 +106,19 @@ export class Utils {
     material.isTransparent = true;
     material.renderState.depthState.enabled = false;
     material.baseColor.set(r, g, b, a);
+    material.name = name.toString();
+    return material;
+  }
+
+  private static _createArcMaterial(
+    engine: Engine,
+    name: State,
+    r: number = 1.0,
+    g: number = 1.0,
+    b: number = 1.0
+  ): ArcMaterial {
+    const material = new ArcMaterial(engine);
+    material.baseColor = new Color(r, g, b, 1.0);
     material.name = name.toString();
     return material;
   }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Modification 
 - use newly reconstructed framebuffer picker for gizmo
 - add arc material to show the half circle of rotate gizmo, instead of direct calculation
 - fix framebuffer picker size bug